### PR TITLE
added nuget package configuration

### DIFF
--- a/create_nupkg.cmd
+++ b/create_nupkg.cmd
@@ -1,0 +1,5 @@
+@echo off
+
+nuget pack src\Markdown.Xaml\Markdown.Xaml.csproj -Build -Symbols -Properties Configuration=Release
+if errorlevel 1 pause
+

--- a/src/Markdown.Xaml/Markdown.Xaml.nuspec
+++ b/src/Markdown.Xaml/Markdown.Xaml.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package>
+    <metadata>
+        <id>$id$</id>
+        <version>$version$</version>
+        <authors>$author$</authors>
+        <owners>Florian Mücke</owners>
+        <licenseUrl>https://github.com/theunrepentantgeek/Markdown.XAML/blob/master/License.txt</licenseUrl>
+        <projectUrl>https://github.com/theunrepentantgeek/Markdown.XAML</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <releaseNotes>Initial release</releaseNotes>
+        <copyright>Copyright (c) 2010 Bevan Arps</copyright>
+        <tags>mardown xaml flowdocument</tags>
+        <dependencies />
+    </metadata>
+</package>

--- a/src/Markdown.Xaml/Properties/AssemblyInfo.cs
+++ b/src/Markdown.Xaml/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Markdown.Xaml")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Markdown XAML processor")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Bevan Arps")]
 [assembly: AssemblyProduct("Markdown.Xaml")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright ©  2013 Bevan Arps")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]


### PR DESCRIPTION
Hi,

I really like your Markdown.XAML implementation. However, it would be a lot easier if one could just install it as a nuget package (see issue #3).

I added a nuget configuration for Markdown.XAML and a simple batch file to create it.
Really, NBD.

I could even upload the package myself, but I would prefer if this would be done by the original maintainer.

Kind regards
Florian Mücke
