### PR TITLE
Fixes to Image Loading

### DIFF
--- a/src/Markdown.Xaml/Markdown.cs
+++ b/src/Markdown.Xaml/Markdown.cs
@@ -396,7 +396,14 @@ namespace Markdown.Xaml
                     url = System.IO.Path.Combine(AssetPathRoot ?? string.Empty, url);
                 }
 
-                imgSource = new BitmapImage(new Uri(url, UriKind.RelativeOrAbsolute));
+                imgSource = new BitmapImage();
+				imgSource.BeginInit();
+				imgSource.CacheOption = BitmapCacheOption.None;
+				imgSource.UriCachePolicy = new RequestCachePolicy(RequestCacheLevel.BypassCache);
+				imgSource.CacheOption = BitmapCacheOption.OnLoad;
+				imgSource.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
+				imgSource.UriSource = new Uri(url);
+				imgSource.EndInit();
             }
             catch (Exception)
             {


### PR DESCRIPTION
* Loading an image will no longer keep its file under lock until exiting the program.
* Images are no longer cached, now you can make changes to the image and it can be reflected if you tell Markdown to reload. (I have not added a method to check for image changes.)