### PR TITLE
Fix incorrect property name/reference in AssetPathRoot DP constructor

### DIFF
--- a/src/Markdown.Xaml/Markdown.cs
+++ b/src/Markdown.Xaml/Markdown.cs
@@ -150,7 +150,7 @@ namespace Markdown.Xaml
         }
 
         public static readonly DependencyProperty AssetPathRootProperty =
-            DependencyProperty.Register("AssetPathRootRoot", typeof(string), typeof(Markdown), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(AssetPathRoot), typeof(string), typeof(Markdown), new PropertyMetadata(null));
 
         public Style TableStyle
         {


### PR DESCRIPTION
There's an error in the constructor for the AssetPathRoot dependency property. The "Root" portion is incorrectly repeated.